### PR TITLE
Update package.json with publisher detail for vsce

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Deliberation Lab Experiment Development Tools
 
-This repository contains tools for researchers and experiment designers to create, validate, and manage experiments for the Deliberation Lab. The main functionality includes a Visual Studio Code (VS Code) extension for syntax highlighting, validation, and YAML schema validation of experiment configuration files (.treatments.yaml).
+This repository contains tools for researchers and experiment designers to create, validate, and manage experiments for the Deliberation Lab. The main functionality includes a Visual Studio Code (VS Code) extension for syntax highlighting, validation, and YAML schema validation of experiment configuration files (.treatments.yaml + elements built in markdown).
 
 ## Project Overview
 
 This VS Code extension enhances experiment design workflows by:
 
-    1.	Providing syntax highlighting for .treatments.yaml files.
+    1.	Providing syntax highlighting for .treatments.yaml files and elements built in markdown.
     2.	Using Zod schemas to validate experiment configurations.
     3.	Diagnosing errors with detailed, line-specific feedback.
     4.	Allowing structured YAML configuration for treatments, sequences, elements, and other experiment components.
@@ -18,14 +18,30 @@ This VS Code extension enhances experiment design workflows by:
 - [ ] Timeline visualization for experiment component display
 - [ ] Participant preview
 
-# Installation
+## Installation for use
+
+- Find our extension here: https://marketplace.visualstudio.com/items?itemName=deliberation-lab.deliberation-lab-tools
+
+## Installation for development/contribution
 
 In a working directory:
 
 ```
-# download the extension from github
-wget https://github.com/Watts-Lab/deliberation-lab-tools/raw/main/deliberation-lab-tools-0.0.1.vsix -P .
+# clone the repository from github
+git clone git@github.com:Watts-Lab/deliberation-lab-tools.git
 
-# install in vscode
-code --install-extension deliberation-lab-tools-0.0.1.vsix
+# generate .vsix file, need @vscode/vsce installed if not already
+vsce package
+
+# install generated package in vscode
+code --install-extension [.vsix file generated above]
+
 ```
+
+## Publishing extension on VSCode Marketplace
+
+- Access our [Azure DevOps organization](https://dev.azure.com/deliberationlab/) -- permission required
+- Create a PAT following [VSCode guidelines](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token)
+  - Provide custom defined scope to `Marketplace` scope with `Manage` access level
+  - Make sure the `Organization` is set to `All accessible organizations` (NOT just for our org)
+- Update [GitHub repository](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) with newly generated PAT

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "deliberation-lab-tools",
+  "publisher": "deliberation-lab",
   "displayName": "Deliberation Lab Experiment Development Tools",
   "description": "Tools for experiment designers to use in creating experiments for deliberation lab",
   "version": "0.0.1",


### PR DESCRIPTION
`publisher` field is required in package.json to publish to VS Code Extension Marketplace, as noted here: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#create-a-publisher