### PR TITLE
Added command to create untitled prompt markdown template

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       {
         "command": "deliberation-lab-tools.helloWorld",
         "title": "Hello World"
+      },
+      {
+        "command": "deliberation-lab-tools.initialPromptMarkdown",
+        "title": "Deliberation Lab Tools: Create Initial Prompt Markdown"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,4 +47,26 @@ export function activate(context: vscode.ExtensionContext) {
       }
     })
   );
+
+  // Command to create initial prompt markdown document
+  context.subscriptions.push(
+    vscode.commands.registerCommand('deliberation-lab-tools.initialPromptMarkdown', async () => {
+      vscode.window.showInformationMessage('Markdown document created');
+
+      const content = `---
+name:
+type: 
+---
+Fill in prompt text here.
+---
+Fill in response text here.
+		`;
+
+      const doc = await vscode.workspace.openTextDocument({
+        language: 'markdown',
+        content
+      });
+    }
+    )
+  )
 }


### PR DESCRIPTION
Will populate a markdown document from the command in the top menu- markdown document is "untitled" and is only saved as a document once the user saves.

Can tweak specifics of the template?